### PR TITLE
Refactor advanced-services.yml to use handlers for SSH

### DIFF
--- a/ansible-modules/advanced-services.yml
+++ b/ansible-modules/advanced-services.yml
@@ -2,14 +2,26 @@
 - name: Advanced Services (Local)
   hosts: local
   become: yes
-  tasks:
-    - name: Ensure SSH service
-      block:
-        - package:
-            name: openssh-server
-            state: present
 
-        - service:
-            name: "{{ 'ssh' if ansible_os_family == 'Debian' else 'sshd' }}"
-            state: started
-            enabled: yes
+  vars:
+    ssh_service_name: "{{ 'ssh' if ansible_os_family == 'Debian' else 'sshd' }}"
+
+  tasks:
+    - name: Ensure SSH package is installed
+      package:
+        name: openssh-server
+        state: present
+      notify: Restart SSH
+
+    - name: Ensure SSH service is running
+      service:
+        name: "{{ ssh_service_name }}"
+        state: started
+        enabled: yes
+
+  handlers:
+    - name: Restart SSH
+      service:
+        name: "{{ ssh_service_name }}"
+        state: restarted
+


### PR DESCRIPTION
This PR improves the `advanced-services.yml ` playbook by following Ansible best practices.

Changes made:

- Introduced a variable for the SSH service name.
- Added a handler to restart SSH only when required.
- Reduced duplication and improved readability.
- Improved idempotency and maintainability.

This makes the playbook more reliable and production-ready.