### PR TITLE
Enhance dynamic-variables.yml with detailed system info

### DIFF
--- a/ansible-variable-and-facts/dynamic-variables.yml
+++ b/ansible-variable-and-facts/dynamic-variables.yml
@@ -1,10 +1,31 @@
 ---
 - name: Dynamic Variables (Local)
   hosts: local
+  gather_facts: yes  # Ensure facts are gathered for dynamic variable calculation
 
   tasks:
-    - set_fact:
+    - name: Set dynamic system profile
+      set_fact:
         system_profile: "{{ ansible_distribution | lower }}_{{ ansible_distribution_major_version }}"
 
-    - debug:
+    - name: Set detailed system info as dynamic facts
+      set_fact:
+        system_info:
+          hostname: "{{ ansible_hostname }}"
+          os: "{{ ansible_distribution }} {{ ansible_distribution_version }}"
+          kernel: "{{ ansible_kernel }}"
+          memory_mb: "{{ ansible_memtotal_mb }}"
+          cpu_cores: "{{ ansible_processor_cores }}"
+
+    - name: Display system profile
+      debug:
         msg: "System Profile: {{ system_profile }}"
+
+    - name: Display detailed system info
+      debug:
+        msg: |
+          Hostname: {{ system_info.hostname }}
+          OS: {{ system_info.os }}
+          Kernel: {{ system_info.kernel }}
+          Memory: {{ system_info.memory_mb }} MB
+          CPU Cores: {{ system_info.cpu_cores }}


### PR DESCRIPTION
This PR improves the ` dynamic-variables.yml `playbook:

- Added a `system_info` dictionary containing hostname, OS, kernel, memory, and CPU cores.
- Maintained the existing `system_profile` fact.
- Added comments for clarity and readability.
- Output is now more informative for use in other tasks or reporting.

This update makes the playbook more suitable for real-world environments and better demonstrates dynamic variables and facts.