### PR TITLE
Update production security policies

### DIFF
--- a/ansible-inv-var/group_vars/production.yml
+++ b/ansible-inv-var/group_vars/production.yml
@@ -4,5 +4,5 @@ monitoring_enabled: true
 timezone: "UTC"
 
 security_policies:
-  session_timeout: 3600
-  failed_login_attempts: 3
+  session_timeout: 7200
+  failed_login_attempts: 5


### PR DESCRIPTION
Updated production security settings:

- Increased session timeout to 2 hours
- Increased failed login attempts to 5

No changes to dev or staging.