### PR TITLE
Reload Apache after content deployment in the ansible-webserver/playbooks/deploy-content.yml

### DIFF
--- a/ansible-webserver/playbooks/deploy-content.yml
+++ b/ansible-webserver/playbooks/deploy-content.yml
@@ -11,3 +11,13 @@
   template:
     src: ../templates/index.html.j2
     dest: "{{ document_root }}/index.html"
+    owner: apache
+    group: apache
+    mode: "0644"
+  notify: reload apache
+
+handlers:
+  - name: reload apache
+    systemd:
+      name: httpd
+      state: reloaded


### PR DESCRIPTION
Added handler notification so Apache reloads when `index.html `is updated.
Prevents serving stale content after deployments.