### PR TITLE
Ensure Apache service starts on both RedHat and Ubuntu in universal package management in the automating-software-package/playbooks

### DIFF
--- a/automating-software-package/playbooks/universal-package-management.yml
+++ b/automating-software-package/playbooks/universal-package-management.yml
@@ -23,3 +23,10 @@
         state: started
         enabled: yes
       when: ansible_os_family == "RedHat"
+
+    - name: Start web server (Debian)
+      systemd:
+        name: apache2
+        state: started
+        enabled: yes
+      when: ansible_os_family == "Debian"


### PR DESCRIPTION
Updated playbook 'universal-package-management.yml' to start the Apache web server on both RedHat and Debian/Ubuntu hosts.  

Changes:
- Added task to start and enable apache2 service on Debian/Ubuntu.
- Retained existing task for httpd on RedHat.
- Ensures playbook works correctly for mixed OS environments.

This improves cross-platform support and ensures the web server is running after installation on all systems.