### PR TITLE
Add Idempotency Test Script for Webserver Playbook in the simple-playbook folder

### DIFF
--- a/simple-playbook/test-idempotency.sh
+++ b/simple-playbook/test-idempotency.sh
@@ -1,24 +1,36 @@
 #!/bin/bash
+# ===================================================================
+# Script: test-idempotency.sh
+# Purpose: Verify that the webserver-setup.yml playbook is idempotent
+# ===================================================================
+
+PLAYBOOK="playbooks/webserver-setup.yml"
+INVENTORY="inventory"
+FIRST_RUN_LOG="first-run.log"
+SECOND_RUN_LOG="second-run.log"
 
 echo "=== Testing Playbook Idempotency ==="
 echo "Running playbook first time..."
-ansible-playbook -i inventory playbooks/webserver-setup.yml > first-run.log 2>&1
+ansible-playbook -i $INVENTORY $PLAYBOOK | tee $FIRST_RUN_LOG
 
+echo ""
 echo "Running playbook second time..."
-ansible-playbook -i inventory playbooks/webserver-setup.yml > second-run.log 2>&1
+ansible-playbook -i $INVENTORY $PLAYBOOK | tee $SECOND_RUN_LOG
 
+echo ""
 echo "Checking for changes in second run..."
-if grep -q "changed=0" second-run.log; then
+if grep -q "changed=0" $SECOND_RUN_LOG; then
     echo "✓ PASS: Playbook is idempotent"
 else
     echo "✗ FAIL: Playbook made unexpected changes"
-    echo "Changes detected:"
-    grep "changed:" second-run.log
+    echo "Detected changes:"
+    grep "changed:" $SECOND_RUN_LOG
 fi
 
-echo "=== Summary ==="
-echo "First run:"
-grep "PLAY RECAP" -A 10 first-run.log
 echo ""
-echo "Second run:"
-grep "PLAY RECAP" -A 10 second-run.log
+echo "=== Summary of Runs ==="
+echo "First run recap:"
+grep "PLAY RECAP" -A 10 $FIRST_RUN_LOG
+echo ""
+echo "Second run recap:"
+grep "PLAY RECAP" -A 10 $SECOND_RUN_LOG


### PR DESCRIPTION
This PR adds a bash script `test-idempotency.sh` to verify that the `webserver-setup.yml` playbook is idempotent.  

Features:
- Runs the playbook twice and logs outputs separately.
- Checks for changes in the second run to confirm idempotency.
- Displays a clear summary of first and second run results.
- Helps ensure consistent playbook behavior without unintended changes.

This update is non-destructive and improves testing and reliability for Ansible playbooks.