### PR TITLE
Refactor user creation playbook using loops and variables in the user-group-management folder

### DIFF
--- a/user-group-management/playbooks/create-users.yml
+++ b/user-group-management/playbooks/create-users.yml
@@ -2,62 +2,55 @@
 - name: Create Users with Different Configurations
   hosts: local
   become: yes
-  tasks:
-    - name: Create developer user - alice
-      user:
-        name: alice
+  vars:
+    users:
+      - name: alice
         comment: "Alice Johnson - Senior Developer"
         uid: 2001
         group: developers
         shell: /bin/bash
         home: /home/alice
-        create_home: yes
-        state: present
-
-    - name: Create developer user - bob
-      user:
-        name: bob
+      - name: bob
         comment: "Bob Smith - Junior Developer"
         uid: 2002
         group: developers
         shell: /bin/bash
         home: /home/bob
-        create_home: yes
-        state: present
-
-    - name: Create tester user - carol
-      user:
-        name: carol
+      - name: carol
         comment: "Carol Davis - QA Tester"
         uid: 2003
         group: testers
         shell: /bin/bash
         home: /home/carol
-        create_home: yes
-        state: present
-
-    - name: Create manager user - david
-      user:
-        name: david
+      - name: david
         comment: "David Wilson - Project Manager"
         uid: 2004
         group: managers
         groups: managers,developers,testers
         shell: /bin/bash
         home: /home/david
-        create_home: yes
-        state: present
-
-    - name: Create contractor user - eve
-      user:
-        name: eve
+      - name: eve
         comment: "Eve Brown - External Contractor"
         uid: 2005
         group: contractors
         shell: /bin/sh
         home: /home/eve
+
+  tasks:
+    - name: Create users
+      user:
+        name: "{{ item.name }}"
+        comment: "{{ item.comment }}"
+        uid: "{{ item.uid }}"
+        group: "{{ item.group }}"
+        groups: "{{ item.groups | default(omit) }}"
+        shell: "{{ item.shell }}"
+        home: "{{ item.home }}"
         create_home: yes
         state: present
+      loop: "{{ users }}"
+      loop_control:
+        label: "{{ item.name }}"
 
     - name: Display created users
       shell: getent passwd | grep -E "(alice|bob|carol|david|eve)"


### PR DESCRIPTION
This PR refactors the `create-users.yml` playbook to improve maintainability and readability by using a loop over a defined users list instead of repeating individual tasks for each user.

### Changes Made:
- Introduced a `users` variable containing all user definitions (name, UID, group, shell, home, etc.)
- Converted repetitive `user` tasks into a single loop with `loop_control.label` for clearer logging
- Used `omit` for optional groups to avoid errors for users without additional groups
- Preserved all original user details and verification steps
- Overall playbook is now shorter, cleaner, and easier to extend with new users in the future

This change does not alter the functionality; it ensures idempotency and simplifies future maintenance.